### PR TITLE
Set DNS cache expiration to 60s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN opkg-install curl ca-certificates && \
          /jre/lib/amd64/libjfx*.so \
          /jre/lib/oblique-fonts \
          /jre/plugin \
-         /tmp/*
+         /tmp/* && \
+         echo 'networkaddress.cache.ttl = 60' >> /jre/lib/security/java.security
 
 CMD ["sh"]


### PR DESCRIPTION
Accoring to AWS Java Guide: http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-jvm-ttl.html
